### PR TITLE
Revert "ci: remove duplicate caching in travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,9 @@ cache:
   timeout: 600
   cargo: true
   directories:
+  - $HOME/.cargo
   - $HOME/.rustup
+  - $TRAVIS_BUILD_DIR/target
 
 before_cache:
   - sudo chmod -R a+r $HOME


### PR DESCRIPTION
This reverts commit a562838d3d194d37f9871dcbe00b783637978f89.

Reduces compile times on travis drastically.