### PR TITLE
grumble(on_seal_block): make `&mut` to avoid clone

### DIFF
--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -415,12 +415,9 @@ impl LockedBlock {
 		}
 
 		s.block.header.set_seal(seal);
-
-		if let Some(new_header) = engine.on_seal_block(&s.block)? {
-			s.block.header = new_header;
-		}
-
+		engine.on_seal_block(&mut s.block)?;
 		s.block.header.compute_hash();
+
 		Ok(SealedBlock {
 			block: s.block
 		})

--- a/ethcore/src/engines/clique/mod.rs
+++ b/ethcore/src/engines/clique/mod.rs
@@ -366,10 +366,10 @@ impl Engine<EthereumMachine> for Clique {
 		Ok(())
 	}
 
-	fn on_seal_block(&self, block: &ExecutedBlock) -> Result<Option<Header>, Error> {
+	fn on_seal_block(&self, block: &mut ExecutedBlock) -> Result<(), Error> {
 		trace!(target: "engine", "on_seal_block");
 
-		let mut header = block.header.clone();
+		let header = &mut block.header;
 
 		let state = self.state_no_backfill(header.parent_hash())
 			.ok_or_else(|| BlockError::UnknownParent(*header.parent_hash()))?;
@@ -440,7 +440,7 @@ impl Engine<EthereumMachine> for Clique {
 
 		trace!(target: "engine", "on_seal_block: finished, final header: {:?}", header);
 
-		Ok(Some(header))
+		Ok(())
 	}
 
 	/// Clique doesn't require external work to seal, so we always return true here.

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -300,7 +300,7 @@ pub trait Engine<M: Machine>: Sync + Send {
 	}
 
 	/// Allow returning new block header after seal generation. Currently only used by Clique.
-	fn on_seal_block(&self, _block: &ExecutedBlock) -> Result<Option<Header>, Error> { Ok(None) }
+	fn on_seal_block(&self, _block: &mut ExecutedBlock) -> Result<(), Error> { Ok(()) }
 
 	/// None means that it requires external input (e.g. PoW) to seal a block.
 	/// Some(true) means the engine is currently prime for seal generation (i.e. node is the current validator).

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -299,7 +299,7 @@ pub trait Engine<M: Machine>: Sync + Send {
 		Ok(())
 	}
 
-	/// Allow returning new block header after seal generation. Currently only used by Clique.
+	/// Allow mutating the header during seal generation. Currently only used by Clique.
 	fn on_seal_block(&self, _block: &mut ExecutedBlock) -> Result<(), Error> { Ok(()) }
 
 	/// None means that it requires external input (e.g. PoW) to seal a block.


### PR DESCRIPTION
Fixes 

Maybe make `Engine::on_seal_block` take a `&mut` of the block instead. This avoids a copy.

_Originally posted by @sorpaas in https://github.com/paritytech/parity-ethereum/diffs_
