### PR TITLE
Reintroduce block metadata

### DIFF
--- a/ethcore/blockchain/src/update.rs
+++ b/ethcore/blockchain/src/update.rs
@@ -48,4 +48,6 @@ pub struct ExtrasInsert {
 	pub fork_choice: ForkChoice,
 	/// Is the inserted block considered finalized.
 	pub is_finalized: bool,
+	/// New block local metadata.
+	pub metadata: Option<Vec<u8>>,
 }

--- a/ethcore/db/src/keys.rs
+++ b/ethcore/db/src/keys.rs
@@ -156,15 +156,16 @@ pub struct BlockDetails {
 	pub children: Vec<H256>,
 	/// Whether the block is considered finalized
 	pub is_finalized: bool,
+    pub metadata: Option<Vec<u8>>
 }
 
 impl rlp::Encodable for BlockDetails {
 	fn rlp_append(&self, stream: &mut rlp::RlpStream) {
-		let use_short_version = !self.is_finalized;
+		let use_short_version = !self.is_finalized && self.metadata.is_none();
 
 		match use_short_version {
 			true => { stream.begin_list(4); },
-			false => { stream.begin_list(5); },
+			false => { stream.begin_list(6); },
 		}
 
 		stream.append(&self.number);
@@ -173,6 +174,7 @@ impl rlp::Encodable for BlockDetails {
 		stream.append_list(&self.children);
 		if !use_short_version {
 			stream.append(&self.is_finalized);
+            stream.append(&self.metadata);
 		}
 	}
 }
@@ -194,6 +196,11 @@ impl rlp::Decodable for BlockDetails {
 				false
 			} else {
 				rlp.val_at(4)?
+			},
+			metadata: if use_short_version {
+				   None
+			} else {
+				   rlp.val_at(5)?
 			},
 		})
 	}

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -498,7 +498,8 @@ impl Importer {
 		let new = ExtendedHeader {
 			header: header.clone(),
 			is_finalized,
-			parent_total_difficulty: chain.block_details(&parent).expect("Parent block is in the database; qed").total_difficulty
+			parent_total_difficulty: chain.block_details(&parent).expect("Parent block is in the database; qed").total_difficulty,
+            metadata: block.metadata,
 		};
 
 		let best = {
@@ -514,6 +515,7 @@ impl Importer {
 				parent_total_difficulty: details.total_difficulty - *header.difficulty(),
 				is_finalized: details.is_finalized,
 				header: header,
+                metadata: details.metadata,
 			}
 		};
 
@@ -2599,6 +2601,7 @@ mod tests {
 				another_client.chain.read().insert_block(&mut batch, encoded::Block::new(new_block), Vec::new(), ExtrasInsert {
 					fork_choice: ::engines::ForkChoice::New,
 					is_finalized: false,
+                    metadata: None,
 				});
 				go_thread.store(true, Ordering::SeqCst);
 			});

--- a/ethcore/src/machine/traits.rs
+++ b/ethcore/src/machine/traits.rs
@@ -35,3 +35,9 @@ pub trait Machine: Send + Sync {
 	/// Increment the balance of an account in the state of the live block.
 	fn add_balance(&self, live: &mut ExecutedBlock, address: &Address, amount: &U256) -> Result<(), Self::Error>;
 }
+
+/// A header with metadata information.
+pub trait WithMetadataHeader: Header {
+	/// Get the current header metadata.
+	fn metadata(&self) -> Option<&[u8]>;
+}

--- a/ethcore/src/snapshot/tests/proof_of_work.rs
+++ b/ethcore/src/snapshot/tests/proof_of_work.rs
@@ -51,6 +51,7 @@ fn chunk_and_restore(amount: u64) {
 		bc.insert_block(&mut batch, block.encoded(), vec![], ExtrasInsert {
 			fork_choice: ::engines::ForkChoice::New,
 			is_finalized: false,
+            metadata: None,
 		});
 		bc.commit();
 	}

--- a/ethcore/src/test_helpers.rs
+++ b/ethcore/src/test_helpers.rs
@@ -378,6 +378,7 @@ pub fn generate_dummy_blockchain(block_number: u32) -> BlockChain {
 		bc.insert_block(&mut batch, encoded::Block::new(create_unverifiable_block(block_order, bc.best_block_hash())), vec![], ExtrasInsert {
 			fork_choice: ::engines::ForkChoice::New,
 			is_finalized: false,
+            metadata: None,
 		});
 		bc.commit();
 	}
@@ -396,6 +397,7 @@ pub fn generate_dummy_blockchain_with_extra(block_number: u32) -> BlockChain {
 		bc.insert_block(&mut batch, encoded::Block::new(create_unverifiable_block_with_extra(block_order, bc.best_block_hash(), None)), vec![], ExtrasInsert {
 			fork_choice: ::engines::ForkChoice::New,
 			is_finalized: false,
+            metadata: None,
 		});
 		bc.commit();
 	}

--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -489,6 +489,7 @@ mod tests {
 					parent: *header.parent_hash(),
 					children: Vec::new(),
 					is_finalized: false,
+                    metadata: None,
 				}
 			})
 		}

--- a/ethcore/types/src/header.rs
+++ b/ethcore/types/src/header.rs
@@ -24,6 +24,8 @@ use bytes::Bytes;
 use rlp::{Rlp, RlpStream, Encodable, DecoderError, Decodable};
 use BlockNumber;
 
+use machine::WithMetadataHeader;
+
 /// Semantic boolean for when a seal/signature is included.
 #[derive(Debug, Clone, Copy)]
 enum Seal {
@@ -42,6 +44,8 @@ pub struct ExtendedHeader {
 	pub is_finalized: bool,
 	/// The parent block difficulty.
 	pub parent_total_difficulty: U256,
+	/// The block metadata information.
+	pub metadata: Option<Vec<u8>>,
 }
 
 /// A block header.
@@ -374,6 +378,11 @@ impl ExtendedHeader {
 		self.parent_total_difficulty + *self.header.difficulty()
 	}
 }
+
+impl WithMetadataHeader for ExtendedHeader {
+	fn metadata(&self) -> Option<&[u8]> { self.metadata.as_ref().map(|v| v.as_ref()) }
+}
+
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This is the first step towards getting https://github.com/goerli/parity-goerli/issues/63 done.  This is my quick and dirty attempt to reverse all changes made in commit `c54beba932e5effb46fd317b0fa2ce6aaafb73e0`.